### PR TITLE
Feature/11 fix fish role - 常に changed になるタスクを修正

### DIFF
--- a/ansible/playbooks/files/fisher-my-setup/fish_plugins
+++ b/ansible/playbooks/files/fisher-my-setup/fish_plugins
@@ -1,13 +1,13 @@
 jorgebucaran/fisher
 jorgebucaran/fish-getopts
-fishpkg/fish-git-util
 fishpkg/fish-humanize-duration
-edc/bass
 0rax/fish-bd
 americanhanko/fish-spin
+edc/bass
 decors/fish-ghq
 franciscolourenco/done
 jethrokuan/fzf
 jethrokuan/z
 joehillen/to-fish
+mbollmann/fishpkgs@main
 sijad/gitignore

--- a/ansible/roles/fish/tasks/14-setup-fisher.yaml
+++ b/ansible/roles/fish/tasks/14-setup-fisher.yaml
@@ -20,6 +20,19 @@
   changed_when: false
   check_mode: false
 
+- name: 14-setup-fisher | Stat temporary home
+  ansible.builtin.stat:
+    path: '{{ temporary_home }}'
+  register: stat_temp_home
+  check_mode: false
+
+- name: 14-setup-fisher | Resolve temporary home
+  ansible.builtin.set_fact:
+    resolved_temp: >-
+      {{ stat_temp_home.stat.lnk_source
+      if stat_temp_home.stat.islnk
+      else stat_temp_home.stat.path }}
+
 - name: 14-setup-fisher | Install fisher
   when: type_fisher.rc != 0
   block:
@@ -41,24 +54,46 @@
     - name: 14-setup-fisher | Copy files to remote
       ansible.builtin.copy:
         src: 'fisher-my-setup/'
-        dest: '{{ temporary_home }}/fisher-my-setup/'
+        dest: '{{ resolved_temp }}/fisher-my-setup/'
         mode: 0755
       changed_when: false
 
+    - name: 14-setup-fisher | Append fish config
+      ansible.builtin.lineinfile:
+        path: '{{ resolved_temp }}/fisher-my-setup/fish_plugins'
+        line: '{{ resolved_temp }}/fisher-my-setup'
+      changed_when: false
+
+- name: 14-setup-fisher | Copy files to remote (for MacOSX)
+  when: ansible_distribution == "MacOSX"
+  block:
     - name: 14-setup-fisher | Copy files to remote (for MacOSX)
       ansible.builtin.copy:
         src: 'fisher-my-setup-mac/'
-        dest: '{{ temporary_home }}/fisher-my-setup-mac/'
+        dest: '{{ resolved_temp }}/fisher-my-setup-mac/'
         mode: 0755
-      when: ansible_distribution == "MacOSX"
       changed_when: false
 
+    - name: 14-setup-fisher | Append fish config (for MacOSX)
+      ansible.builtin.lineinfile:
+        path: '{{ resolved_temp }}/fisher-my-setup/fish_plugins'
+        line: '{{ resolved_temp }}/fisher-my-setup-mac'
+      changed_when: false
+
+- name: 14-setup-fisher | Copy files to remote (for WSL)
+  when: type_cmd.rc == 0
+  block:
     - name: 14-setup-fisher | Copy files to remote (for WSL)
       ansible.builtin.copy:
         src: 'fisher-my-setup-wsl/'
-        dest: '{{ temporary_home }}/fisher-my-setup-wsl/'
+        dest: '{{ resolved_temp }}/fisher-my-setup-wsl/'
         mode: 0755
-      when: type_cmd.rc == 0
+      changed_when: false
+
+    - name: 14-setup-fisher | Append fish config (for WSL)
+      ansible.builtin.lineinfile:
+        path: '{{ resolved_temp }}/fisher-my-setup/fish_plugins'
+        line: '{{ resolved_temp }}/fisher-my-setup-wsl'
       changed_when: false
 
 - name: 14-setup-fisher | Configure fisher with SHELL env
@@ -66,17 +101,17 @@
     SHELL: '{{ fish_path }}'
   block:
     - name: 14-setup-fisher | Update fisher itself
-      ansible.builtin.shell: fish -l -c 'fisher update jorgebucaran/fisher'
+      ansible.builtin.shell:
+        fish -l -c 'fisher update jorgebucaran/fisher'
       args:
         executable: '{{ fish_path }}'
       changed_when: false
 
     - name: 14-setup-fisher | Copy fish_plugin file
       ansible.builtin.copy:
-        src: 'fisher-my-setup/fish_plugins'
+        src: '{{ resolved_temp }}/fisher-my-setup/fish_plugins'
         dest: '{{ xdg_config_home }}/fish/fish_plugins'
         mode: 0644
-        follow: no
 
     - name: 14-setup-fisher | Update fisher plugins
       ansible.builtin.shell: fish -l -c 'fisher update'
@@ -85,26 +120,3 @@
       register: update_fisher_plugins
       failed_when: update_fisher_plugins.stderr is search('Cannot install')
       changed_when: false
-
-    - name: 14-setup-fisher | Install fish config
-      ansible.builtin.shell:
-        fish -l -c 'fisher install "{{ temporary_home }}/fisher-my-setup"'
-      args:
-        executable: '{{ fish_path }}'
-      changed_when: false
-
-    - name: 14-setup-fisher | Install fish config (for MacOSX)
-      ansible.builtin.shell:
-        fish -l -c 'fisher install "{{ temporary_home }}/fisher-my-setup-mac"'
-      args:
-        executable: '{{ fish_path }}'
-      changed_when: false
-      when: ansible_distribution == "MacOSX"
-
-    - name: 14-setup-fisher | Install fish config (for WSL)
-      ansible.builtin.shell:
-        fish -l -c 'fisher install "{{ temporary_home }}/fisher-my-setup-wsl"'
-      args:
-        executable: '{{ fish_path }}'
-      changed_when: false
-      when: type_cmd.rc == 0


### PR DESCRIPTION
solves: #11 

## 前提 / Prerequisites
fishロールの実行で常に changed になるタスクがある

## なぜこのPRが必要になったか / Why do we need this PR
更新の有無が分かりづらいのを解消したい

## なにをやったか / What I did

- 爆散した `fishpkg/fish-git-util` プラグインの避難先 `mbollmann/fishpkgs@main` を選択
- `fisher-my-plugin/fish_plugins` にその他のローカルプラグインフォルダパスを追記するタスク
  - 🙅 オリジナルfish_pluginsを /tmp にコピー → fish_pluginsインストール → ローカルプラグインインストール → fish_pluginsにパスが書き込まれて差分発生💥💥💥
  - 🙆 オリジナルfish_pluginsを /tmp にコピー → 先にローカルプラグインのパスをfish_pluginsに追記 → fish_pluginsインストール → ローカルプラグインの追記がないので差分が発生しない🎉🎉🎉