### PR TITLE
feature/14-add-code-formatter - prettierを導入する

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -32,5 +32,8 @@ warn_list:
   - ignore-errors
   - risky-shell-pipe
 
+skip_list:
+  - yaml[line-length]
+
 # Offline mode disables installation of requirements.yml and schema refreshing
 offline: false

--- a/.gitignore
+++ b/.gitignore
@@ -90,4 +90,5 @@ $RECYCLE.BIN/
 
 # End of https://www.gitignore.io/api/code,vim,windows,macos
 
+ansible/galaxy_cache
 ansible/tmp

--- a/.mise.toml
+++ b/.mise.toml
@@ -4,6 +4,7 @@ shellcheck = "latest"
 yamllint = "latest"
 markdownlint-cli2 = "latest"
 "go:github.com/rhysd/actionlint/cmd/actionlint" = "latest"
+"npm:prettier" = "latest"
 
 [env]
 '_'.file = ".env"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,13 @@
 exclude: ^.github/pull_request_template.md$
 
 repos:
+  - repo: https://github.com/c18t/pre-commit-hooks
+    rev: v1.3.0
+    hooks:
+      - id: pretty-quick
+      - id: shellcheck
+      - id: yamllint
+
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: '2.1.5'
     hooks:
@@ -11,12 +18,6 @@ repos:
     rev: v0.12.1
     hooks:
       - id: markdownlint-cli2
-
-  - repo: https://github.com/c18t/pre-commit-hooks
-    rev: v1.2.0
-    hooks:
-      - id: shellcheck
-      - id: yamllint
 
   - repo: https://github.com/rhysd/actionlint
     rev: v1.6.27

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "oderwat.indent-rainbow",
+    "redhat.vscode-yaml"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
+}

--- a/ansible/playbooks/handlers/includes/set_global_path.yaml
+++ b/ansible/playbooks/handlers/includes/set_global_path.yaml
@@ -16,6 +16,5 @@
 
 - name: set_global_path | set global path
   become: true
-  ansible.builtin.command:
-    /bin/launchctl config user path "{{ echo_path.stdout }}"
+  ansible.builtin.command: /bin/launchctl config user path "{{ echo_path.stdout }}"
   when: which_fish.rc == 0

--- a/ansible/playbooks/iapetus-macos.yaml
+++ b/ansible/playbooks/iapetus-macos.yaml
@@ -55,17 +55,10 @@
       ansible.builtin.import_role:
         name: mise
       vars:
-        mise_config:
-          '{{ dotfiles }}/mise/config-macos.toml'
-        mise_default_go_packages:
-          '{{ dotfiles }}/mise/.default-go-packages'
-        mise_default_python_packages:
-          '{{ dotfiles }}/mise/.default-python-packages'
-        mise_default_npm_packages:
-          '{{ dotfiles }}/mise/.default-npm-packages'
-        mise_default_gems:
-          '{{ dotfiles }}/mise/.default-gems'
-        mise_default_mix_commands:
-          '{{ dotfiles }}/mise/.default-mix-commands'
-        mise_default_perl_modules:
-          '{{ dotfiles }}/mise/.default-perl-modules'
+        mise_config: '{{ dotfiles }}/mise/config-macos.toml'
+        mise_default_go_packages: '{{ dotfiles }}/mise/.default-go-packages'
+        mise_default_python_packages: '{{ dotfiles }}/mise/.default-python-packages'
+        mise_default_npm_packages: '{{ dotfiles }}/mise/.default-npm-packages'
+        mise_default_gems: '{{ dotfiles }}/mise/.default-gems'
+        mise_default_mix_commands: '{{ dotfiles }}/mise/.default-mix-commands'
+        mise_default_perl_modules: '{{ dotfiles }}/mise/.default-perl-modules'

--- a/ansible/playbooks/khronos-windows.yaml
+++ b/ansible/playbooks/khronos-windows.yaml
@@ -228,17 +228,10 @@
       ansible.builtin.import_role:
         name: mise
       vars:
-        mise_config:
-          '{{ dotfiles }}/mise/config-wsl.toml'
-        mise_default_go_packages:
-          '{{ dotfiles }}/mise/.default-go-packages'
-        mise_default_python_packages:
-          '{{ dotfiles }}/mise/.default-python-packages'
-        mise_default_npm_packages:
-          '{{ dotfiles }}/mise/.default-npm-packages'
-        mise_default_gems:
-          '{{ dotfiles }}/mise/.default-gems'
-        mise_default_mix_commands:
-          '{{ dotfiles }}/mise/.default-mix-commands'
-        mise_default_perl_modules:
-          '{{ dotfiles }}/mise/.default-perl-modules'
+        mise_config: '{{ dotfiles }}/mise/config-wsl.toml'
+        mise_default_go_packages: '{{ dotfiles }}/mise/.default-go-packages'
+        mise_default_python_packages: '{{ dotfiles }}/mise/.default-python-packages'
+        mise_default_npm_packages: '{{ dotfiles }}/mise/.default-npm-packages'
+        mise_default_gems: '{{ dotfiles }}/mise/.default-gems'
+        mise_default_mix_commands: '{{ dotfiles }}/mise/.default-mix-commands'
+        mise_default_perl_modules: '{{ dotfiles }}/mise/.default-perl-modules'

--- a/ansible/playbooks/vars/common.yaml
+++ b/ansible/playbooks/vars/common.yaml
@@ -7,8 +7,7 @@ user: '{{ my_user | default(ansible_env.USER) }}'
 editor: '{{ my_editor | default(ansible_env.EDITOR) | default(None) }}'
 visual: '{{ my_visual | default(ansible_env.VISUAL) | default(None) }}'
 # temporary
-temporary_home:
-  '{{ my_temporary_home | default(ansible_env.TEMP) | default(None) }}'
+temporary_home: '{{ my_temporary_home | default(ansible_env.TEMP) | default(None) }}'
 # XDG
 xdg_config_home: >-
   {{ my_xdg_config_home

--- a/ansible/roles/fish/tasks/14-setup-fisher.yaml
+++ b/ansible/roles/fish/tasks/14-setup-fisher.yaml
@@ -101,8 +101,7 @@
     SHELL: '{{ fish_path }}'
   block:
     - name: 14-setup-fisher | Update fisher itself
-      ansible.builtin.shell:
-        fish -l -c 'fisher update jorgebucaran/fisher'
+      ansible.builtin.shell: fish -l -c 'fisher update jorgebucaran/fisher'
       args:
         executable: '{{ fish_path }}'
       changed_when: false

--- a/ansible/roles/fish/tasks/includes/change_login_shell_macos.yaml
+++ b/ansible/roles/fish/tasks/includes/change_login_shell_macos.yaml
@@ -1,7 +1,6 @@
 ---
 - name: change_login_shell_macos | Check user's login shell (for macOSX)
-  ansible.builtin.shell:
-    dscl . -read '/Users/{{ user }}' UserShell | grep -q '{{ fish_path }}'
+  ansible.builtin.shell: dscl . -read '/Users/{{ user }}' UserShell | grep -q '{{ fish_path }}'
   register: check_fish_is_login_shell
   failed_when: check_fish_is_login_shell.rc not in [0, 1]
   changed_when: false
@@ -17,8 +16,7 @@
 
     - name: change_login_shell_macos | Change login shell to fish
       become: true
-      ansible.builtin.script:
-        common/chsh.exp "{{ fish_path }}" "{{ my_password }}" "{{ user }}"
+      ansible.builtin.script: common/chsh.exp "{{ fish_path }}" "{{ my_password }}" "{{ user }}"
       args:
         executable: '{{ which_expect.stdout }}'
 

--- a/ansible/roles/fish/tasks/includes/change_login_shell_other.yaml
+++ b/ansible/roles/fish/tasks/includes/change_login_shell_other.yaml
@@ -1,7 +1,6 @@
 ---
 - name: change_login_shell_other | Check user's login shell (for other)
-  ansible.builtin.shell:
-    cat /etc/passwd | grep -q '{{ home }}:{{ fish_path }}'
+  ansible.builtin.shell: cat /etc/passwd | grep -q '{{ home }}:{{ fish_path }}'
   register: check_fish_is_login_shell
   failed_when: check_fish_is_login_shell.rc not in [0, 1]
   changed_when: false
@@ -17,8 +16,7 @@
 
     - name: change_login_shell_other | Change login shell to fish
       become: true
-      ansible.builtin.script:
-        common/chsh.exp "{{ fish_path }}" "{{ my_password }}" "{{ user }}"
+      ansible.builtin.script: common/chsh.exp "{{ fish_path }}" "{{ my_password }}" "{{ user }}"
       args:
         executable: '{{ which_expect.stdout }}'
 

--- a/ansible/roles/fish/tasks/includes/set_env_other.yaml
+++ b/ansible/roles/fish/tasks/includes/set_env_other.yaml
@@ -63,8 +63,7 @@
     - '/usr/lib/x86_64-linux-gnu' # linuxbrewのlibより先に読み込ませる(for curl)
 
 - name: set_env_other | Add Linuxbrew to LD_LIBRARY_PATH (for other)
-  ansible.builtin.shell:
-    set -Ux LD_LIBRARY_PATH "{{ item }}" $LD_LIBRARY_PATH
+  ansible.builtin.shell: set -Ux LD_LIBRARY_PATH "{{ item }}" $LD_LIBRARY_PATH
   args:
     executable: '{{ fish_path }}'
   when: ld_lib_path is not search(item)
@@ -74,8 +73,7 @@
     - '/usr/lib/x86_64-linux-gnu' # linuxbrewのlibより先に読み込ませる(for curl)
 
 - name: set_env_other | Add Linuxbrew to C_INCLUDE_PATH (for other)
-  ansible.builtin.shell:
-    set -Ux C_INCLUDE_PATH "{{ item }}" $C_INCLUDE_PATH
+  ansible.builtin.shell: set -Ux C_INCLUDE_PATH "{{ item }}" $C_INCLUDE_PATH
   args:
     executable: '{{ fish_path }}'
   when: c_include_path is not search(item)
@@ -84,8 +82,7 @@
     - '{{ brew_prefix }}/include'
 
 - name: set_env_other | Add Linuxbrew to CPLUS_INCLUDE_PATH (for other)
-  ansible.builtin.shell:
-    set -Ux CPLUS_INCLUDE_PATH "{{ item }}" $CPLUS_INCLUDE_PATH
+  ansible.builtin.shell: set -Ux CPLUS_INCLUDE_PATH "{{ item }}" $CPLUS_INCLUDE_PATH
   args:
     executable: '{{ fish_path }}'
   when: cplus_include_path is not search(item)
@@ -94,8 +91,7 @@
     - '{{ brew_prefix }}/include'
 
 - name: set_env_other | Add Linuxbrew to OBJC_INCLUDE_PATH (for other)
-  ansible.builtin.shell:
-    set -Ux OBJC_INCLUDE_PATH "{{ item }}" $OBJC_INCLUDE_PATH
+  ansible.builtin.shell: set -Ux OBJC_INCLUDE_PATH "{{ item }}" $OBJC_INCLUDE_PATH
   args:
     executable: '{{ fish_path }}'
   when: objc_include_path is not search(item)

--- a/ansible/roles/homebrew/tasks/11-install-and-upgrade-applications.yaml
+++ b/ansible/roles/homebrew/tasks/11-install-and-upgrade-applications.yaml
@@ -17,14 +17,10 @@
     | Exec includes/brew_tasks.yaml (for other)
   # environmentへのomitの指定がうまくいかないので ansible_distribution で場合分け
   environment:
-    PATH:
-      '{{ brew_prefix }}/bin:{{ ansible_env.PATH | default("") }}'
-    LIBRARY_PATH:
-      '{{ brew_prefix }}/lib:{{ ansible_env.LIBRARY_PATH | default("") }}'
-    LD_LIBRARY_PATH:
-      '{{ brew_prefix }}/lib:{{ ansible_env.LD_LIBRARY_PATH | default("") }}'
-    C_INCLUDE_PATH:
-      '{{ brew_prefix }}/include:{{ ansible_env.C_INCLUDE_PATH | default("") }}'
+    PATH: '{{ brew_prefix }}/bin:{{ ansible_env.PATH | default("") }}'
+    LIBRARY_PATH: '{{ brew_prefix }}/lib:{{ ansible_env.LIBRARY_PATH | default("") }}'
+    LD_LIBRARY_PATH: '{{ brew_prefix }}/lib:{{ ansible_env.LD_LIBRARY_PATH | default("") }}'
+    C_INCLUDE_PATH: '{{ brew_prefix }}/include:{{ ansible_env.C_INCLUDE_PATH | default("") }}'
     CPLUS_INCLUDE_PATH: >-
       {{ brew_prefix }}/include:{{
       ansible_env.CPLUS_INCLUDE_PATH | default("")

--- a/ansible/roles/mise/meta/main.yaml
+++ b/ansible/roles/mise/meta/main.yaml
@@ -16,7 +16,6 @@ galaxy_info:
       versions:
         - all
 
-  galaxy_tags:
-    []
+  galaxy_tags: []
 
 dependencies: []

--- a/ansible/roles/mise/tasks/10-setup-mise.yaml
+++ b/ansible/roles/mise/tasks/10-setup-mise.yaml
@@ -50,6 +50,5 @@
     chdir: '{{ home }}'
     executable: '{{ fish_path }}'
   register: mise_install
-  changed_when:
-    mise_install.stderr is not search('mise all runtimes are installed')
+  changed_when: mise_install.stderr is not search('mise all runtimes are installed')
   notify: update_global_path

--- a/ansible/roles/winget/tasks/12-configure-winget-packages.yaml
+++ b/ansible/roles/winget/tasks/12-configure-winget-packages.yaml
@@ -1,7 +1,6 @@
 ---
 - name: 12-configure-winget-packages | Prepend to PATH
-  ansible.builtin.script:
-    prependpath.vbs "{{ item.type }}" "{{ item.path }}"
+  ansible.builtin.script: prependpath.vbs "{{ item.type }}" "{{ item.path }}"
   args:
     executable: cscript.exe
   changed_when: false
@@ -16,11 +15,9 @@
         mode: 0755
 
     - name: 12-configure-winget-packages | Find Visual Studio
-      ansible.windows.win_shell:
-        .\vswhere.exe -all -prerelease -latest -format json
+      ansible.windows.win_shell: .\vswhere.exe -all -prerelease -latest -format json
       args:
-        chdir:
-          C:\Program Files (x86)\Microsoft Visual Studio\Installer
+        chdir: C:\Program Files (x86)\Microsoft Visual Studio\Installer
       register: find_vs
       changed_when: false
       ignore_errors: true

--- a/ansible/roles/winget/tasks/includes/install-package.yaml
+++ b/ansible/roles/winget/tasks/includes/install-package.yaml
@@ -1,8 +1,7 @@
 ---
 - name: install-package | Check package exists ({{ item.name }})
   become: true
-  ansible.windows.win_shell:
-    winget list -e --id '{{ item.list_id | default(item.name) }}'
+  ansible.windows.win_shell: winget list -e --id '{{ item.list_id | default(item.name) }}'
   register: check_package
   changed_when: false
   failed_when: false

--- a/ansible/roles/wsl/tasks/main.yaml
+++ b/ansible/roles/wsl/tasks/main.yaml
@@ -3,8 +3,6 @@
   tags: wsl
   block:
     - name: Configure fonts
-      ansible.builtin.import_tasks:
-        10-install-fonts.yaml
+      ansible.builtin.import_tasks: 10-install-fonts.yaml
     - name: Configure fstab
-      ansible.builtin.import_tasks:
-        11-make-fstab.yaml
+      ansible.builtin.import_tasks: 11-make-fstab.yaml


### PR DESCRIPTION
solves: #14 

## 前提 / Prerequisites

- コードフォーマッターが設定されていない

## なにをやったか / What I did

- VSCodeのワークスペース設定でファイル保存時に prettier に掛けるように設定
- git commit時に pretty-quick に掛けるように pre-commit を設定
- yamllintで既にチェックしているので、ansible-lintの `yaml[line-length]` を skip_lists に追加
