### PR TITLE
Feature/update 202405

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -20,6 +20,6 @@ jobs:
       - name: run pre-commit
         uses: pre-commit/action@v3.0.1
       - name: run ansible-lint
-        uses: ansible/ansible-lint@v24.2.2
+        uses: ansible/ansible-lint@v24.5.0
         env:
           ANSIBLE_HOME: ./ansible

--- a/ansible/playbooks/files/homebrew/Brewfile-mac
+++ b/ansible/playbooks/files/homebrew/Brewfile-mac
@@ -1,7 +1,6 @@
 tap "buo/cask-upgrade" # for `brew cu` command
 tap "gromgit/fuse" # for sshfs-mac
 tap "homebrew/cask-fonts" # for font installation
-tap "homebrew/cask-versions" # for beta fomulae
 # Automate deployment, configuration, and upgrading
 brew "ansible"
 # Checks ansible playbooks for practices and behaviour
@@ -22,6 +21,8 @@ brew "fish"
 brew "fop" # for asdf-erlang
 # Software library to render fonts
 brew "freetype" # for asdf-php
+# GNU compiler collection
+brew "gfortran" # part of gcc
 # Graphics library to dynamically manipulate images
 brew "gd" # for asdf-php
 # GNU internationalization (i18n) and localization (l10n) library
@@ -70,6 +71,8 @@ brew "mise"
 brew "molecule"
 # Fast, highly customisable system info script
 brew "neofetch"
+# Regular expressions library
+brew "oniguruma" # for asdf-php
 # Cryptography and SSL/TLS Toolkit
 brew "openssl@1.1" # for asdf-erlang, asdf-php
 brew "openssl@3" # for asdf-erlang, asdf-php
@@ -113,8 +116,6 @@ cask "font-hackgen-nerd"
 cask "font-ricty-diminished"
 # GIT client
 cask "fork"
-# GNU compiler collection
-cask "gfortran" # part of gcc
 # Free and open-source image editor
 cask "gimp"
 # Web browser
@@ -128,7 +129,7 @@ cask "google-japanese-ime"
 # Tools to protect your files
 cask "gpg-suite-no-mail"
 # Android USB tethering driver
-cask "horndis"
+#cask "horndis"
 # Vector graphics editor
 cask "inkscape"
 # Terminal emulator as alternative to Apple's Terminal app
@@ -137,24 +138,24 @@ cask "iterm2"
 cask "licecap"
 # File system integration
 cask "macfuse"
-# Full TeX Live distribution with GUI applications
-cask "mactex"
+# Full TeX Live distribution without GUI applications
+cask "mactex-no-gui"
 # Minimal installer for conda
 cask "miniconda"
 # Open source implementation of Microsoft's .NET Framework
-cask "mono-mdk"
+#cask "mono-mdk-for-visual-studio" # install with "visual-studio"
 # App to write, plan, collaborate, and get organised
 cask "notion"
 # Command-line shell and scripting language
 cask "powershell"
 # Flexible software sketchbook and a language for learning how to code
 cask "processing"
+# All-in-one bookmark manager
+cask "raindropio"
 # Video chat, voice call and instant messaging application
 cask "skype"
 # Team communication and collaboration software
 cask "slack"
-# Video game digital distribution service
-cask "steam"
 # To-do list
 cask "todoist"
 # Management tool for Unity
@@ -168,7 +169,7 @@ cask "wacom-tablet"
 # Mind mapping and brainstorming tool
 cask "xmind"
 mas "Kindle", id: 302584613
-mas "LimeChat", id: 414030210
+#mas "LimeChat", id: 414030210
 mas "LINE", id: 539883307
 mas "Microsoft Excel", id: 462058435
 mas "Microsoft Remote Desktop", id: 1295203466

--- a/ansible/playbooks/handlers/handlers_macos.yaml
+++ b/ansible/playbooks/handlers/handlers_macos.yaml
@@ -1,15 +1,15 @@
 ---
 - name: Restart Dock
-  listen: restart_dock
+  listen: RestartDock
   ansible.builtin.command: killall 'Dock'
   changed_when: true
 
 - name: Restart Finder
-  listen: restart_finder
+  listen: RestartFinder
   ansible.builtin.command: killall 'Finder'
   changed_when: true
 
 - name: Update global path
-  listen: update_global_path
+  listen: UpdateGlobalPath
   # import_tasksにすると通知を受け取れなくなる
   ansible.builtin.include_tasks: includes/set_global_path.yaml

--- a/ansible/playbooks/handlers/handlers_wsl.yaml
+++ b/ansible/playbooks/handlers/handlers_wsl.yaml
@@ -1,6 +1,6 @@
 ---
 # update global path
 - name: Update global path
-  listen: update_global_path
+  listen: UpdateGlobalPath
   ansible.builtin.debug:
     msg: I have nothing to do.

--- a/ansible/roles/fish/tasks/includes/change_login_shell_macos.yaml
+++ b/ansible/roles/fish/tasks/includes/change_login_shell_macos.yaml
@@ -1,32 +1,32 @@
 ---
-- name: change_login_shell_macos | Check user's login shell (for macOSX)
+- name: includes | change_login_shell_macos | Check user's login shell (for macOSX)
   ansible.builtin.shell: dscl . -read '/Users/{{ user }}' UserShell | grep -q '{{ fish_path }}'
   register: check_fish_is_login_shell
   failed_when: check_fish_is_login_shell.rc not in [0, 1]
   changed_when: false
   check_mode: false
 
-- name: change_login_shell_macos | Change login shell to fish
+- name: includes | change_login_shell_macos | Change login shell to fish
   when: check_fish_is_login_shell.rc != 0
   block:
-    - name: change_login_shell_macos | Find expect
+    - name: includes | change_login_shell_macos | Find expect
       ansible.builtin.command: which expect
       register: which_expect
       changed_when: false
 
-    - name: change_login_shell_macos | Change login shell to fish
+    - name: includes | change_login_shell_macos | Change login shell to fish
       become: true
       ansible.builtin.script: common/chsh.exp "{{ fish_path }}" "{{ my_password }}" "{{ user }}"
       args:
         executable: '{{ which_expect.stdout }}'
 
-    - name: change_login_shell_macos | Read current UserShell
+    - name: includes | change_login_shell_macos | Read current UserShell
       ansible.builtin.command: dscl . -read '/Users/{{ user }}' UserShell
       register: recheck_fish_is_login_shell
       changed_when: false
       check_mode: false
 
-    - name: change_login_shell_macos | Recheck user's login shell
+    - name: includes | change_login_shell_macos | Recheck user's login shell
       ansible.builtin.shell: >-
         echo {{ recheck_fish_is_login_shell.stdout }}
         | grep -q '{{ fish_path }}'

--- a/ansible/roles/fish/tasks/includes/change_login_shell_other.yaml
+++ b/ansible/roles/fish/tasks/includes/change_login_shell_other.yaml
@@ -1,32 +1,32 @@
 ---
-- name: change_login_shell_other | Check user's login shell (for other)
+- name: includes | change_login_shell_other | Check user's login shell (for other)
   ansible.builtin.shell: cat /etc/passwd | grep -q '{{ home }}:{{ fish_path }}'
   register: check_fish_is_login_shell
   failed_when: check_fish_is_login_shell.rc not in [0, 1]
   changed_when: false
   check_mode: false
 
-- name: change_login_shell_other | Change login shell to fish
+- name: includes | change_login_shell_other | Change login shell to fish
   when: check_fish_is_login_shell.rc != 0
   block:
-    - name: change_login_shell_other | Find expect
+    - name: includes | change_login_shell_other | Find expect
       ansible.builtin.command: which expect
       register: which_expect
       changed_when: false
 
-    - name: change_login_shell_other | Change login shell to fish
+    - name: includes | change_login_shell_other | Change login shell to fish
       become: true
       ansible.builtin.script: common/chsh.exp "{{ fish_path }}" "{{ my_password }}" "{{ user }}"
       args:
         executable: '{{ which_expect.stdout }}'
 
-    - name: change_login_shell_other | Read current usershell
+    - name: includes | change_login_shell_other | Read current usershell
       ansible.builtin.shell: cat /etc/passwd | grep -e '^{{ user }}:'
       register: recheck_fish_is_login_shell
       changed_when: false
       check_mode: false
 
-    - name: change_login_shell_other | Recheck user's login shell
+    - name: includes | change_login_shell_other | Recheck user's login shell
       ansible.builtin.shell: >-
         echo {{ recheck_fish_is_login_shell.stdout }}
         | grep -q '{{ home }}:{{ fish_path }}'

--- a/ansible/roles/fish/tasks/includes/set_brew_prefix.yaml
+++ b/ansible/roles/fish/tasks/includes/set_brew_prefix.yaml
@@ -1,15 +1,15 @@
 ---
-- name: set_brew_prefix | Check Homebrew/Linuxbrew
+- name: includes | set_brew_prefix | Check Homebrew/Linuxbrew
   ansible.builtin.command: which brew
   changed_when: false
   check_mode: false
 
-- name: set_brew_prefix | Get brew --prefix
+- name: includes | set_brew_prefix | Get brew --prefix
   ansible.builtin.command: brew --prefix
   register: get_brew_prefix
   changed_when: false
   check_mode: false
 
-- name: set_brew_prefix | Set Homebrew/Linuxbrew prefix
+- name: includes | set_brew_prefix | Set Homebrew/Linuxbrew prefix
   ansible.builtin.set_fact:
     brew_prefix: '{{ get_brew_prefix.stdout }}'

--- a/ansible/roles/fish/tasks/includes/set_env_macos.yaml
+++ b/ansible/roles/fish/tasks/includes/set_env_macos.yaml
@@ -1,5 +1,5 @@
 ---
-- name: set_env_macos | Set environment variables (for MacOSX)
+- name: includes | set_env_macos | Set environment variables (for MacOSX)
   ansible.builtin.shell: >-
     set -Ux ANDROID_HOME {{ home }}/Library/Android/sdk;
     set -Ux ANDRIOD_SDK_ROOT {{ home }}/Library/Android/sdk;
@@ -8,18 +8,18 @@
     executable: '{{ fish_path }}'
   changed_when: false
 
-- name: set_env_macos | Add tools to fish_user_paths (for MacOSX)
+- name: includes | set_env_macos | Add tools to fish_user_paths (for MacOSX)
   ansible.builtin.shell: set -U fish_user_paths $fish_user_paths "{{ item }}"
   args:
     executable: '{{ fish_path }}'
   when: fish_user_paths is not search(item)
   changed_when: true
-  notify: update_global_path
+  notify: UpdateGlobalPath
   loop:
     - '{{ home }}/Library/Android/sdk/tools'
     - '{{ home }}/Library/Android/sdk/platform-tools'
 
-- name: set_env_macos | Make PKG_CONFIG_PATH config (for MacOSX)
+- name: includes | set_env_macos | Make PKG_CONFIG_PATH config (for MacOSX)
   ansible.builtin.copy:
     dest: '{{ xdg_config_home }}/fish/conf.d/{{ item }}.fish'
     content: >

--- a/ansible/roles/fish/tasks/includes/set_env_other.yaml
+++ b/ansible/roles/fish/tasks/includes/set_env_other.yaml
@@ -1,10 +1,10 @@
 ---
-- name: set_env_other | Set_fact
+- name: includes | set_env_other | Set_fact
   block:
-    - name: set_env_other | Get brew prefix
+    - name: includes | set_env_other | Get brew prefix
       ansible.builtin.import_tasks: includes/set_brew_prefix.yaml
 
-    - name: set_env_other | Echo LIBRARY_PATH (for other)
+    - name: includes | set_env_other | Echo LIBRARY_PATH (for other)
       ansible.builtin.shell: echo $LIBRARY_PATH
       args:
         executable: '{{ fish_path }}'
@@ -12,7 +12,7 @@
       changed_when: false
       check_mode: false
 
-    - name: set_env_other | Echo LD_LIBRARY_PATH (for other)
+    - name: includes | set_env_other | Echo LD_LIBRARY_PATH (for other)
       ansible.builtin.shell: echo $LD_LIBRARY_PATH
       args:
         executable: '{{ fish_path }}'
@@ -20,7 +20,7 @@
       changed_when: false
       check_mode: false
 
-    - name: set_env_other | Echo C_INCLUDE_PATH (for other)
+    - name: includes | set_env_other | Echo C_INCLUDE_PATH (for other)
       ansible.builtin.shell: echo $C_INCLUDE_PATH
       args:
         executable: '{{ fish_path }}'
@@ -28,7 +28,7 @@
       changed_when: false
       check_mode: false
 
-    - name: set_env_other | Echo CPLUS_INCLUDE_PATH (for other)
+    - name: includes | set_env_other | Echo CPLUS_INCLUDE_PATH (for other)
       ansible.builtin.shell: echo $CPLUS_INCLUDE_PATH
       args:
         executable: '{{ fish_path }}'
@@ -36,7 +36,7 @@
       changed_when: false
       check_mode: false
 
-    - name: set_env_other | Echo OBJC_INCLUDE_PATH (for other)
+    - name: includes | set_env_other | Echo OBJC_INCLUDE_PATH (for other)
       ansible.builtin.shell: echo $OBJC_INCLUDE_PATH
       args:
         executable: '{{ fish_path }}'
@@ -44,7 +44,7 @@
       changed_when: false
       check_mode: false
 
-    - name: set_env_other | Set lib_path and include_path (for other)
+    - name: includes | set_env_other | Set lib_path and include_path (for other)
       ansible.builtin.set_fact:
         lib_path: '{{ echo_lib_path.stdout }}'
         ld_lib_path: '{{ echo_ld_lib_path.stdout }}'
@@ -52,7 +52,7 @@
         cplus_include_path: '{{ echo_cplus_include_path.stdout }}'
         objc_include_path: '{{ echo_objc_include_path.stdout }}'
 
-- name: set_env_other | Add Linuxbrew to LIBRARY_PATH (for other)
+- name: includes | set_env_other | Add Linuxbrew to LIBRARY_PATH (for other)
   ansible.builtin.shell: set -Ux LIBRARY_PATH "{{ item }}" $LIBRARY_PATH
   args:
     executable: '{{ fish_path }}'
@@ -62,7 +62,7 @@
     - '{{ brew_prefix }}/lib'
     - '/usr/lib/x86_64-linux-gnu' # linuxbrewのlibより先に読み込ませる(for curl)
 
-- name: set_env_other | Add Linuxbrew to LD_LIBRARY_PATH (for other)
+- name: includes | set_env_other | Add Linuxbrew to LD_LIBRARY_PATH (for other)
   ansible.builtin.shell: set -Ux LD_LIBRARY_PATH "{{ item }}" $LD_LIBRARY_PATH
   args:
     executable: '{{ fish_path }}'
@@ -72,7 +72,7 @@
     - '{{ brew_prefix }}/lib'
     - '/usr/lib/x86_64-linux-gnu' # linuxbrewのlibより先に読み込ませる(for curl)
 
-- name: set_env_other | Add Linuxbrew to C_INCLUDE_PATH (for other)
+- name: includes | set_env_other | Add Linuxbrew to C_INCLUDE_PATH (for other)
   ansible.builtin.shell: set -Ux C_INCLUDE_PATH "{{ item }}" $C_INCLUDE_PATH
   args:
     executable: '{{ fish_path }}'
@@ -81,7 +81,7 @@
   with_items:
     - '{{ brew_prefix }}/include'
 
-- name: set_env_other | Add Linuxbrew to CPLUS_INCLUDE_PATH (for other)
+- name: includes | set_env_other | Add Linuxbrew to CPLUS_INCLUDE_PATH (for other)
   ansible.builtin.shell: set -Ux CPLUS_INCLUDE_PATH "{{ item }}" $CPLUS_INCLUDE_PATH
   args:
     executable: '{{ fish_path }}'
@@ -90,7 +90,7 @@
   with_items:
     - '{{ brew_prefix }}/include'
 
-- name: set_env_other | Add Linuxbrew to OBJC_INCLUDE_PATH (for other)
+- name: includes | set_env_other | Add Linuxbrew to OBJC_INCLUDE_PATH (for other)
   ansible.builtin.shell: set -Ux OBJC_INCLUDE_PATH "{{ item }}" $OBJC_INCLUDE_PATH
   args:
     executable: '{{ fish_path }}'
@@ -99,7 +99,7 @@
   with_items:
     - '{{ brew_prefix }}/include'
 
-- name: set_env_other | Make PKG_CONFIG_PATH config (for other)
+- name: includes | set_env_other | Make PKG_CONFIG_PATH config (for other)
   ansible.builtin.copy:
     dest: '{{ xdg_config_home }}/fish/conf.d/{{ item }}.fish'
     content: >
@@ -108,7 +108,7 @@
     mode: 0644
   with_items: []
 
-- name: set_env_other | Add other PKG_CONFIG_PATH config (for other)
+- name: includes | set_env_other | Add other PKG_CONFIG_PATH config (for other)
   ansible.builtin.copy:
     dest: '{{ xdg_config_home }}/fish/conf.d/{{ item.name }}.fish'
     content: >

--- a/ansible/roles/fish/tasks/includes/set_fish_path.yaml
+++ b/ansible/roles/fish/tasks/includes/set_fish_path.yaml
@@ -1,10 +1,10 @@
 ---
-- name: set_fish_path | Find fish
+- name: includes | set_fish_path | Find fish
   ansible.builtin.command: which fish
   register: which_fish
   changed_when: false
   check_mode: false
 
-- name: set_fish_path | Set fish_path
+- name: includes | set_fish_path | Set fish_path
   ansible.builtin.set_fact:
     fish_path: '{{ which_fish.stdout }}'

--- a/ansible/roles/fish/tasks/includes/set_fish_user_paths.yaml
+++ b/ansible/roles/fish/tasks/includes/set_fish_user_paths.yaml
@@ -1,5 +1,5 @@
 ---
-- name: set_fish_user_paths | Check fish_user_paths
+- name: includes | set_fish_user_paths | Check fish_user_paths
   ansible.builtin.shell: echo $fish_user_paths
   args:
     executable: '{{ fish_path }}'
@@ -7,6 +7,6 @@
   changed_when: false
   check_mode: false
 
-- name: set_fish_user_paths | Set fish_user_paths
+- name: includes | set_fish_user_paths | Set fish_user_paths
   ansible.builtin.set_fact:
     fish_user_paths: '{{ check_fish_user_paths.stdout }}'

--- a/ansible/roles/home/tasks/includes/10-make-directories-windows.yaml
+++ b/ansible/roles/home/tasks/includes/10-make-directories-windows.yaml
@@ -1,17 +1,17 @@
 ---
-- name: 10-make-directories-windows | Make standard directories
+- name: includes | 10-make-directories-windows | Make standard directories
   ansible.windows.win_file:
     state: directory
     path: '{{ home }}/{{ item }}'
   loop: '{{ home_standard_directories }}'
 
-- name: 10-make-directories-windows | Copy desktop.ini
+- name: includes | 10-make-directories-windows | Copy desktop.ini
   ansible.windows.win_copy:
     src: '{{ item }}_desktop.ini'
     dest: '{{ home }}\{{ item }}\desktop.ini'
   loop: '{{ home_standard_directories }}'
 
-- name: 10-make-directories-windows | Make config directories
+- name: includes | 10-make-directories-windows | Make config directories
   ansible.windows.win_file:
     state: directory
     path: '{{ item }}'

--- a/ansible/roles/home/tasks/includes/10-make-directories.yaml
+++ b/ansible/roles/home/tasks/includes/10-make-directories.yaml
@@ -1,5 +1,5 @@
 ---
-- name: 10-make-directories | Make standard directories
+- name: includes | 10-make-directories | Make standard directories
   ansible.builtin.file:
     state: directory
     follow: true
@@ -7,7 +7,7 @@
     mode: 0755
   loop: '{{ home_standard_directories }}'
 
-- name: 10-make-directories | Make config directories
+- name: includes | 10-make-directories | Make config directories
   ansible.builtin.file:
     state: directory
     follow: true

--- a/ansible/roles/home/tasks/includes/11-make-symbolic-links-windows.wsl.yaml
+++ b/ansible/roles/home/tasks/includes/11-make-symbolic-links-windows.wsl.yaml
@@ -1,5 +1,5 @@
 ---
-- name: 11-make-symbolic-links-windows.wsl | Link to host google drive directory
+- name: includes | 11-make-symbolic-links-windows.wsl | Link to host google drive directory
   become: true
   ansible.builtin.file:
     state: link
@@ -9,5 +9,5 @@
     src: '/mnt/g/マイドライブ'
     dest: '{{ home }}/GoogleDrive'
 
-- name: 11-make-symbolic-links-windows.wsl | Make symbolic links
+- name: includes | 11-make-symbolic-links-windows.wsl | Make symbolic links
   ansible.builtin.import_tasks: 11-make-symbolic-links.yaml

--- a/ansible/roles/home/tasks/includes/11-make-symbolic-links-windows.yaml
+++ b/ansible/roles/home/tasks/includes/11-make-symbolic-links-windows.yaml
@@ -1,5 +1,5 @@
 ---
-- name: 11-make-symbolic-links-windows | Set link directory or file items
+- name: includes | 11-make-symbolic-links-windows | Set link directory or file items
   ansible.builtin.set_fact:
     link_dir_items:
       # Google Drive
@@ -21,14 +21,14 @@
       - path: '{{ home_my_git_config }}'
         dest: '{{ home_git_config }}'
 
-- name: 11-make-symbolic-links-windows | Check that directory link sources
+- name: includes | 11-make-symbolic-links-windows | Check that directory link sources
   ansible.windows.win_stat:
     path: '{{ item.path }}'
   register: stat_link_source_dir
   failed_when: not stat_link_source_dir.stat.exists
   loop: '{{ link_dir_items }}'
 
-- name: 11-make-symbolic-links-windows | Make directory links
+- name: includes | 11-make-symbolic-links-windows | Make directory links
   become: true
   ansible.windows.win_shell: >-
     if (-Not(Test-Path "{{ item.dest }}")) { `
@@ -41,14 +41,14 @@
   changed_when: make_dir_link.rc == 2
   loop: '{{ link_dir_items }}'
 
-- name: 11-make-symbolic-links-windows | Check that file link sources
+- name: includes | 11-make-symbolic-links-windows | Check that file link sources
   ansible.windows.win_stat:
     path: '{{ item.path }}'
   register: stat_link_source_file
   failed_when: not stat_link_source_file.stat.exists
   loop: '{{ link_file_items }}'
 
-- name: 11-make-symbolic-links-windows | Make file links
+- name: includes | 11-make-symbolic-links-windows | Make file links
   become: true
   ansible.windows.win_shell: >-
     if (-Not(Test-Path "{{ item.dest }}")) { `

--- a/ansible/roles/home/tasks/includes/11-make-symbolic-links.yaml
+++ b/ansible/roles/home/tasks/includes/11-make-symbolic-links.yaml
@@ -1,5 +1,5 @@
 ---
-- name: 11-make-symbolic-links | Set link items
+- name: includes | 11-make-symbolic-links | Set link items
   ansible.builtin.set_fact:
     link_items:
       # ssh
@@ -9,14 +9,14 @@
       - path: '{{ home_my_git_config }}'
         dest: '{{ home }}/.gitconfig'
 
-- name: 11-make-symbolic-links | Check that link sources exists
+- name: includes | 11-make-symbolic-links | Check that link sources exists
   ansible.builtin.stat:
     path: '{{ item.path }}'
   register: stat_link_source
   failed_when: not stat_link_source.stat.exists or stat_link_source.stat.isdir
   loop: '{{ link_items }}'
 
-- name: 11-make-symbolic-links | Link to files
+- name: includes | 11-make-symbolic-links | Link to files
   become: true
   ansible.builtin.file:
     state: link

--- a/ansible/roles/homebrew/tasks/includes/brew_tasks.yaml
+++ b/ansible/roles/homebrew/tasks/includes/brew_tasks.yaml
@@ -1,6 +1,6 @@
 ---
 - name: >-
-    brew_tasks | Update Homebrew and upgrade formulae
+    includes | brew_tasks | Update Homebrew and upgrade formulae
     (for {{ brew_distr }})
   community.general.homebrew:
     update_homebrew: true
@@ -11,7 +11,7 @@
       or ansible_env.GITHUB_ACTIONS != 'true'
 
 - name: >-
-    brew_tasks | Install with brew bundle
+    includes | brew_tasks | Install with brew bundle
     ({{ "file: " + (homebrew_brewfile | basename) + ", for " + (brew_distr) }})
   ansible.builtin.command: >-
     brew bundle install -v --no-lock --file "{{ homebrew_brewfile }}"

--- a/ansible/roles/homebrew/tasks/includes/set_brew_prefix.yaml
+++ b/ansible/roles/homebrew/tasks/includes/set_brew_prefix.yaml
@@ -1,16 +1,16 @@
 ---
-- name: set_brew_prefix | Check Homebrew
+- name: includes | set_brew_prefix | Check Homebrew
   ansible.builtin.command: which brew
   register: which_brew
   changed_when: false
   check_mode: false
 
-- name: set_brew_prefix | Get brew --prefix
+- name: includes | set_brew_prefix | Get brew --prefix
   ansible.builtin.command: brew --prefix
   register: get_brew_prefix
   changed_when: false
   check_mode: false
 
-- name: set_brew_prefix | Set Homebrew prefix
+- name: includes | set_brew_prefix | Set Homebrew prefix
   ansible.builtin.set_fact:
     brew_prefix: '{{ get_brew_prefix.stdout }}'

--- a/ansible/roles/mise/tasks/10-setup-mise.yaml
+++ b/ansible/roles/mise/tasks/10-setup-mise.yaml
@@ -51,4 +51,4 @@
     executable: '{{ fish_path }}'
   register: mise_install
   changed_when: mise_install.stderr is search('✓ installed')
-  notify: update_global_path
+  notify: UpdateGlobalPath

--- a/ansible/roles/mise/tasks/10-setup-mise.yaml
+++ b/ansible/roles/mise/tasks/10-setup-mise.yaml
@@ -50,5 +50,5 @@
     chdir: '{{ home }}'
     executable: '{{ fish_path }}'
   register: mise_install
-  changed_when: mise_install.stderr is not search('mise all runtimes are installed')
+  changed_when: mise_install.stderr is search('✓ installed')
   notify: update_global_path

--- a/ansible/roles/os_macos/tasks/10-dock.yaml
+++ b/ansible/roles/os_macos/tasks/10-dock.yaml
@@ -5,7 +5,7 @@
     key: autohide
     type: int
     value: '1'
-  notify: restart_dock
+  notify: RestartDock
 
 - name: 10-dock | Dock settings mineffect
   community.general.osx_defaults:
@@ -13,7 +13,7 @@
     key: mineffect
     type: string
     value: genie
-  notify: restart_dock
+  notify: RestartDock
 
 - name: 10-dock | Dock settings tilesize
   community.general.osx_defaults:
@@ -21,4 +21,4 @@
     key: tilesize
     type: float
     value: '{{ os_macos_dock_tilesize }}'
-  notify: restart_dock
+  notify: RestartDock

--- a/ansible/roles/os_macos/tasks/11-finder.yaml
+++ b/ansible/roles/os_macos/tasks/11-finder.yaml
@@ -5,4 +5,4 @@
     key: AppleShowAllFiles
     type: string
     value: 'TRUE'
-  notify: restart_finder
+  notify: RestartFinder

--- a/ansible/roles/winget/tasks/includes/install-package.yaml
+++ b/ansible/roles/winget/tasks/includes/install-package.yaml
@@ -1,12 +1,12 @@
 ---
-- name: install-package | Check package exists ({{ item.name }})
+- name: includes | install-package | Check package exists ({{ item.name }})
   become: true
   ansible.windows.win_shell: winget list -e --id '{{ item.list_id | default(item.name) }}'
   register: check_package
   changed_when: false
   failed_when: false
 
-- name: install-package | Install package {{ item.name }}
+- name: includes | install-package | Install package {{ item.name }}
   become: true
   ansible.windows.win_shell: >-
     winget install -e --id '{{ item.name }}'


### PR DESCRIPTION
solves: -

## 前提 / Prerequisites

- 5月分のソフトウェアアップデート

## なぜこのPRが必要になったか / Why do we need this PR

- Apple SiliconのMacBookに乗り換えたときのセットアップで色々更新が入った

## なにをやったか / What I did

- bugfix:
  - mise install -y が常に changed になる不具合を修正
  - tap cask-versionsがcaskに統合されたため削除
  - gfortranが brew ではなく cask になっていた
- software update:
  - mise phpビルド用に oniguruma を追加
  - mactexをGUIなしバージョンに変更
  - Raindrop.ioを追加
  - Steamを削除
  - horndis, LimeChatをコメントアウト
- ansible-lint update:
  - name[casing]: notify名のケースも警告されるようになった
  - name[prefix]: 孫フォルダも警告されるようになった

## 影響範囲  / Affected by the change

とくになし

## 懸念事項 / Concerns

Apple SiliconのRosetta周りで対応が必要になるかも
