### PR TITLE
Feature/update 202509

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -4,7 +4,6 @@ shellcheck = "latest"
 yamllint = "latest"
 markdownlint-cli2 = "latest"
 "go:github.com/rhysd/actionlint/cmd/actionlint" = "latest"
-"npm:prettier" = "latest"
 
 [env]
 '_'.file = ".env"

--- a/ansible/playbooks/files/homebrew/Brewfile-mac
+++ b/ansible/playbooks/files/homebrew/Brewfile-mac
@@ -1,6 +1,5 @@
 tap "buo/cask-upgrade" # for `brew cu` command
 tap "gromgit/fuse" # for sshfs-mac
-tap "homebrew/cask-fonts" # for font installation
 # Automate deployment, configuration, and upgrading
 brew "ansible"
 # Checks ansible playbooks for practices and behaviour
@@ -117,7 +116,7 @@ cask "font-ricty-diminished"
 # GIT client
 cask "fork"
 # Free and open-source image editor
-cask "gimp"
+#cask "gimp"
 # Web browser
 cask "google-chrome"
 # Set of tools to manage resources and applications hosted on Google Cloud
@@ -131,9 +130,7 @@ cask "gpg-suite-no-mail"
 # Android USB tethering driver
 #cask "horndis"
 # Vector graphics editor
-cask "inkscape"
-# Terminal emulator as alternative to Apple's Terminal app
-cask "iterm2"
+#cask "inkscape"
 # Animated screen capture application
 cask "licecap"
 # File system integration
@@ -152,6 +149,8 @@ cask "powershell"
 cask "processing"
 # All-in-one bookmark manager
 cask "raindropio"
+# Hardware-accelerated GPU terminal emulator
+cask "rio"
 # Video chat, voice call and instant messaging application
 cask "skype"
 # Team communication and collaboration software

--- a/ansible/playbooks/handlers/includes/set_global_path.yaml
+++ b/ansible/playbooks/handlers/includes/set_global_path.yaml
@@ -16,5 +16,5 @@
 
 - name: set_global_path | set global path
   become: true
-  ansible.builtin.command: /bin/launchctl config user path "{{ echo_path.stdout }}"
+  ansible.builtin.command: /bin/launchctl config user path "{{ echo_path.stdout | replace(':~/', ':$HOME/') | expandvars }}"
   when: which_fish.rc == 0

--- a/ansible/roles/fish/tasks/10-add-fish-to-shells.yaml
+++ b/ansible/roles/fish/tasks/10-add-fish-to-shells.yaml
@@ -15,8 +15,8 @@
     - name: 10-add-fish-to-shells | Add fish to shells
       become: true
       ansible.builtin.shell: echo {{ fish_path }} | tee -a /etc/shells
-      register: add_fish_in_shells
-      changed_when: add_fish_in_shells.rc == 0
+      register: fish_add_fish_in_shells
+      changed_when: fish_add_fish_in_shells.rc == 0
 
     - name: 10-add-fish-to-shells | Recheck fish is enabled as login shells
       ansible.builtin.shell: cat /etc/shells | grep -q '{{ fish_path }}'

--- a/ansible/roles/fish/tasks/12-setup-resources.yaml
+++ b/ansible/roles/fish/tasks/12-setup-resources.yaml
@@ -12,16 +12,16 @@
 
 - name: 12-setup-resources | Set link items
   ansible.builtin.set_fact:
-    link_items:
+    fish_link_items:
       - path: '{{ dotfiles }}/fish/{{ fish_shell_config }}'
         dest: '{{ xdg_config_home }}/fish/config.fish'
 
 - name: 12-setup-resources | Check for the existence of link sources
   ansible.builtin.stat:
     path: '{{ item.path }}'
-  register: stat_link_source
-  failed_when: not stat_link_source.stat.exists or stat_link_source.stat.isdir
-  loop: '{{ link_items }}'
+  register: fish_stat_link_source
+  failed_when: not fish_stat_link_source.stat.exists or fish_stat_link_source.stat.isdir
+  loop: '{{ fish_link_items }}'
 
 - name: 12-setup-resources | Link to files
   become: true
@@ -32,4 +32,4 @@
     owner: '{{ user }}'
     src: '{{ item.path }}'
     dest: '{{ item.dest }}'
-  loop: '{{ link_items }}'
+  loop: '{{ fish_link_items }}'

--- a/ansible/roles/fish/tasks/14-setup-fisher.yaml
+++ b/ansible/roles/fish/tasks/14-setup-fisher.yaml
@@ -6,8 +6,8 @@
   ansible.builtin.shell: type fisher
   args:
     executable: '{{ fish_path }}'
-  register: type_fisher
-  failed_when: type_fisher.rc not in [0, 1, 126, 127]
+  register: fish_type_fisher
+  failed_when: fish_type_fisher.rc not in [0, 1, 126, 127]
   changed_when: false
   check_mode: false
 
@@ -15,26 +15,26 @@
   ansible.builtin.shell: type cmd.exe
   args:
     executable: '{{ fish_path }}'
-  register: type_cmd
-  failed_when: type_cmd.rc not in [0, 1]
+  register: fish_type_cmd
+  failed_when: fish_type_cmd.rc not in [0, 1]
   changed_when: false
   check_mode: false
 
 - name: 14-setup-fisher | Stat temporary home
   ansible.builtin.stat:
     path: '{{ temporary_home }}'
-  register: stat_temp_home
+  register: fish_stat_temp_home
   check_mode: false
 
 - name: 14-setup-fisher | Resolve temporary home
   ansible.builtin.set_fact:
-    resolved_temp: >-
-      {{ stat_temp_home.stat.lnk_source
-      if stat_temp_home.stat.islnk
-      else stat_temp_home.stat.path }}
+    fish_resolved_temp: >-
+      {{ fish_stat_temp_home.stat.lnk_source
+      if fish_stat_temp_home.stat.islnk
+      else fish_stat_temp_home.stat.path }}
 
 - name: 14-setup-fisher | Install fisher
-  when: type_fisher.rc != 0
+  when: fish_type_fisher.rc != 0
   block:
     - name: 14-setup-fisher | Install fisher
       ansible.builtin.shell: >-
@@ -54,14 +54,14 @@
     - name: 14-setup-fisher | Copy files to remote
       ansible.builtin.copy:
         src: 'fisher-my-setup/'
-        dest: '{{ resolved_temp }}/fisher-my-setup/'
+        dest: '{{ fish_resolved_temp }}/fisher-my-setup/'
         mode: 0755
       changed_when: false
 
     - name: 14-setup-fisher | Append fish config
       ansible.builtin.lineinfile:
-        path: '{{ resolved_temp }}/fisher-my-setup/fish_plugins'
-        line: '{{ resolved_temp }}/fisher-my-setup'
+        path: '{{ fish_resolved_temp }}/fisher-my-setup/fish_plugins'
+        line: '{{ fish_resolved_temp }}/fisher-my-setup'
       changed_when: false
 
 - name: 14-setup-fisher | Copy files to remote (for MacOSX)
@@ -70,30 +70,30 @@
     - name: 14-setup-fisher | Copy files to remote (for MacOSX)
       ansible.builtin.copy:
         src: 'fisher-my-setup-mac/'
-        dest: '{{ resolved_temp }}/fisher-my-setup-mac/'
+        dest: '{{ fish_resolved_temp }}/fisher-my-setup-mac/'
         mode: 0755
       changed_when: false
 
     - name: 14-setup-fisher | Append fish config (for MacOSX)
       ansible.builtin.lineinfile:
-        path: '{{ resolved_temp }}/fisher-my-setup/fish_plugins'
-        line: '{{ resolved_temp }}/fisher-my-setup-mac'
+        path: '{{ fish_resolved_temp }}/fisher-my-setup/fish_plugins'
+        line: '{{ fish_resolved_temp }}/fisher-my-setup-mac'
       changed_when: false
 
 - name: 14-setup-fisher | Copy files to remote (for WSL)
-  when: type_cmd.rc == 0
+  when: fish_type_cmd.rc == 0
   block:
     - name: 14-setup-fisher | Copy files to remote (for WSL)
       ansible.builtin.copy:
         src: 'fisher-my-setup-wsl/'
-        dest: '{{ resolved_temp }}/fisher-my-setup-wsl/'
+        dest: '{{ fish_resolved_temp }}/fisher-my-setup-wsl/'
         mode: 0755
       changed_when: false
 
     - name: 14-setup-fisher | Append fish config (for WSL)
       ansible.builtin.lineinfile:
-        path: '{{ resolved_temp }}/fisher-my-setup/fish_plugins'
-        line: '{{ resolved_temp }}/fisher-my-setup-wsl'
+        path: '{{ fish_resolved_temp }}/fisher-my-setup/fish_plugins'
+        line: '{{ fish_resolved_temp }}/fisher-my-setup-wsl'
       changed_when: false
 
 - name: 14-setup-fisher | Configure fisher with SHELL env
@@ -108,7 +108,7 @@
 
     - name: 14-setup-fisher | Copy fish_plugin file
       ansible.builtin.copy:
-        src: '{{ resolved_temp }}/fisher-my-setup/fish_plugins'
+        src: '{{ fish_resolved_temp }}/fisher-my-setup/fish_plugins'
         dest: '{{ xdg_config_home }}/fish/fish_plugins'
         mode: 0644
 
@@ -116,6 +116,6 @@
       ansible.builtin.shell: fish -l -c 'fisher update'
       args:
         executable: '{{ fish_path }}'
-      register: update_fisher_plugins
-      failed_when: update_fisher_plugins.stderr is search('Cannot install')
+      register: fish_update_fisher_plugins
+      failed_when: fish_update_fisher_plugins.stderr is search('Cannot install')
       changed_when: false

--- a/ansible/roles/fish/tasks/15-setup-graphviz.yaml
+++ b/ansible/roles/fish/tasks/15-setup-graphviz.yaml
@@ -3,7 +3,7 @@
   ansible.builtin.shell: which dot
   args:
     executable: '{{ fish_path }}'
-  register: which_dot
+  register: fish_which_dot
   changed_when: false
   failed_when: false
   check_mode: false
@@ -12,14 +12,14 @@
   ansible.builtin.shell: echo $GRAPHVIZ_DOT
   args:
     executable: '{{ fish_path }}'
-  register: echo_dot
+  register: fish_echo_dot
   changed_when: false
   failed_when: false
   check_mode: false
 
 - name: 15-setup-graphviz | Set environment variables GRAPHVIZ_DOT
-  ansible.builtin.shell: set -Ux GRAPHVIZ_DOT {{ which_dot.stdout }}
+  ansible.builtin.shell: set -Ux GRAPHVIZ_DOT {{ fish_which_dot.stdout }}
   args:
     executable: '{{ fish_path }}'
-  when: which_dot.rc == 0 and echo_dot.stdout != which_dot.stdout
+  when: fish_which_dot.rc == 0 and fish_echo_dot.stdout != fish_which_dot.stdout
   changed_when: true

--- a/ansible/roles/homebrew/tasks/10-install-homebrew.yaml
+++ b/ansible/roles/homebrew/tasks/10-install-homebrew.yaml
@@ -1,8 +1,8 @@
 ---
 - name: 10-install-homebrew | Check brew
   ansible.builtin.command: which brew
-  register: which_brew
-  failed_when: which_brew.rc not in [0, 1, 126, 127]
+  register: homebrew_which_brew
+  failed_when: homebrew_which_brew.rc not in [0, 1, 126, 127]
   changed_when: false
   check_mode: false
 
@@ -10,5 +10,5 @@
   ansible.builtin.command: >-
     /bin/bash -c "$(curl -fsSL
     https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-  when: which_brew.rc != 0
+  when: homebrew_which_brew.rc != 0
   changed_when: true

--- a/ansible/roles/homebrew/tasks/includes/brew_tasks.yaml
+++ b/ansible/roles/homebrew/tasks/includes/brew_tasks.yaml
@@ -14,7 +14,7 @@
     includes | brew_tasks | Install with brew bundle
     ({{ "file: " + (homebrew_brewfile | basename) + ", for " + (brew_distr) }})
   ansible.builtin.command: >-
-    brew bundle install -v --no-lock --file "{{ homebrew_brewfile }}"
+    brew bundle install -v --file "{{ homebrew_brewfile }}"
   register: brew_bundle
   changed_when: >-
     brew_bundle.rc == 0 and brew_bundle.stdout

--- a/ansible/roles/iterm2/tasks/10-install-imgcat.yaml
+++ b/ansible/roles/iterm2/tasks/10-install-imgcat.yaml
@@ -1,8 +1,8 @@
 ---
 - name: 10-install-imgcat | Check imgcat
   ansible.builtin.command: which imgcat
-  register: which_imgcat
-  failed_when: which_imgcat.rc not in [0, 1, 126, 127]
+  register: iterm2_which_imgcat
+  failed_when: iterm2_which_imgcat.rc not in [0, 1, 126, 127]
   changed_when: false
   check_mode: false
 
@@ -11,4 +11,4 @@
     url: https://iterm2.com/utilities/imgcat
     dest: /usr/local/bin/imgcat
     mode: 0755
-  when: which_imgcat.rc != 0
+  when: iterm2_which_imgcat.rc != 0

--- a/ansible/roles/mise/tasks/01-gather-facts.yaml
+++ b/ansible/roles/mise/tasks/01-gather-facts.yaml
@@ -1,10 +1,10 @@
 ---
 - name: 01-gather-facts | Find fish
   ansible.builtin.command: which fish
-  register: which_fish
+  register: mise_which_fish
   changed_when: false
   check_mode: false
 
 - name: 01-gather-facts | Set fish_path
   ansible.builtin.set_fact:
-    fish_path: '{{ which_fish.stdout }}'
+    mise_fish_path: '{{ mise_which_fish.stdout }}'

--- a/ansible/roles/mise/tasks/10-setup-mise.yaml
+++ b/ansible/roles/mise/tasks/10-setup-mise.yaml
@@ -10,7 +10,7 @@
 
 - name: 10-setup-mise | Set link items
   ansible.builtin.set_fact:
-    link_items:
+    mise_link_items:
       - path: '{{ mise_config }}'
         dest: '{{ xdg_config_home }}/mise/config.toml'
       - path: '{{ mise_default_go_packages }}'
@@ -29,9 +29,9 @@
 - name: 10-setup-mise | Check that link sources exists
   ansible.builtin.stat:
     path: '{{ item.path }}'
-  register: stat_link_source
-  failed_when: not stat_link_source.stat.exists or stat_link_source.stat.isdir
-  loop: '{{ link_items }}'
+  register: mise_stat_link_source
+  failed_when: not mise_stat_link_source.stat.exists or mise_stat_link_source.stat.isdir
+  loop: '{{ mise_link_items }}'
 
 - name: 10-setup-mise | Link to files
   become: true
@@ -42,13 +42,13 @@
     owner: '{{ user }}'
     src: '{{ item.path }}'
     dest: '{{ item.dest }}'
-  loop: '{{ link_items }}'
+  loop: '{{ mise_link_items }}'
 
 - name: 10-setup-mise | Setup tools with mise
   ansible.builtin.shell: mise install -y
   args:
     chdir: '{{ home }}'
-    executable: '{{ fish_path }}'
+    executable: '{{ mise_fish_path }}'
   register: mise_install
   changed_when: mise_install.stderr is search('✓ installed')
   notify: UpdateGlobalPath

--- a/ansible/roles/nvim/tasks/10-configure.yaml
+++ b/ansible/roles/nvim/tasks/10-configure.yaml
@@ -10,17 +10,17 @@
 
 - name: 10-configure | Set link items
   ansible.builtin.set_fact:
-    link_items:
+    nvim_link_items:
       - { path: '{{ dotfiles }}/nvim', dest: '{{ xdg_config_home }}/nvim' }
 
 - name: 10-configure | Check for the existence of link sources
   ansible.builtin.stat:
     path: '{{ item.path }}'
-  register: stat_link_source
+  register: nvim_stat_link_source
   failed_when: >-
-    not stat_link_source.stat.exists
-    or not stat_link_source.stat.isdir
-  with_items: '{{ link_items }}'
+    not nvim_stat_link_source.stat.exists
+    or not nvim_stat_link_source.stat.isdir
+  with_items: '{{ nvim_link_items }}'
 
 - name: 10-configure | Link to directory
   become: true
@@ -31,4 +31,4 @@
     owner: '{{ user }}'
     src: '{{ item.path }}'
     dest: '{{ item.dest }}'
-  with_items: '{{ link_items }}'
+  with_items: '{{ nvim_link_items }}'

--- a/ansible/roles/os_windows/tasks/13-install-fonts.yaml
+++ b/ansible/roles/os_windows/tasks/13-install-fonts.yaml
@@ -4,8 +4,8 @@
     url: https://rictyfonts.github.io/files/ricty_diminished-4.1.1.tar.gz
     dest: '{{ ansible_env.TEMP }}\ricty_diminished-4.1.1.tar.gz'
     force: false
-  register: download_ricty_diminished
-  failed_when: download_ricty_diminished.status_code not in [200, 403]
+  register: os_windows_download_ricty_diminished
+  failed_when: os_windows_download_ricty_diminished.status_code not in [200, 403]
   ignore_errors: true
 
 # - name: install PSCX
@@ -16,20 +16,20 @@
 
 - name: 13-install-fonts | Install PSCX
   ansible.windows.win_shell: Install-Package pscx -Force -AllowClobber
-  register: install_pscx
+  register: os_windows_install_pscx
 
 - name: 13-install-fonts | Unzip Ricty Diminished
   community.windows.win_unzip:
-    src: '{{ download_ricty_diminished.dest }}'
-    dest: '{{ download_ricty_diminished.dest }}.unzip'
+    src: '{{ os_windows_download_ricty_diminished.dest }}'
+    dest: '{{ os_windows_download_ricty_diminished.dest }}.unzip'
     recurse: true
-    creates: '{{ download_ricty_diminished.dest }}.unzip'
+    creates: '{{ os_windows_download_ricty_diminished.dest }}.unzip'
 
 - name: 13-install-fonts | Install Ricty Diminished
   ansible.windows.win_shell: |-
     $ShellAppFontNamespace = 0x14; `
     $Fonts = Get-ChildItem `
-      -Path "{{ download_ricty_diminished.dest }}.unzip\*" `
+      -Path "{{ os_windows_download_ricty_diminished.dest }}.unzip\*" `
       -Include ('*.fon','*.otf','*.ttc','*.ttf'); `
     $ShellApp = New-Object -ComObject Shell.Application; `
     $FontsFolder = $ShellApp.NameSpace($ShellAppFontNamespace); `

--- a/ansible/roles/scoop/tasks/10-install-scoop.yaml
+++ b/ansible/roles/scoop/tasks/10-install-scoop.yaml
@@ -3,9 +3,9 @@
   ansible.windows.win_shell: >-
     if (-Not(gcm scoop -ErrorAction SilentlyContinue))
     { iwr -useb get.scoop.sh | iex; }
-  register: install_scoop
+  register: scoop_install_scoop
   changed_when: >-
-    install_scoop.stdout
+    scoop_install_scoop.stdout
     is search('Scoop was installed successfully!')
 
 - name: 10-install-scoop | Install scoop dependencies
@@ -13,8 +13,8 @@
   ansible.windows.win_shell: >-
     if ((scoop info {{ item }}) -match "Installed: No")
     { scoop install {{ item }}; }
-  register: install_scoop_dependency
+  register: scoop_install_scoop_dependency
   changed_when: >-
-    install_scoop_dependency.stdout
+    scoop_install_scoop_dependency.stdout
     is search('was installed successfully!')
   loop: [git]

--- a/ansible/roles/scoop/tasks/11-add-backets.yaml
+++ b/ansible/roles/scoop/tasks/11-add-backets.yaml
@@ -1,7 +1,7 @@
 ---
 - name: 11-add-backets | Add scoop backets
   ansible.windows.win_shell: scoop bucket add {{ item }}
-  register: add_bucket
-  changed_when: add_bucket.stdout is search('was added successfully.')
-  failed_when: add_bucket.rc > 1
+  register: scoop_add_bucket
+  changed_when: scoop_add_bucket.stdout is search('was added successfully.')
+  failed_when: scoop_add_bucket.rc > 1
   loop: '{{ scoop_buckets }}'

--- a/ansible/roles/scoop/tasks/12-install-packages.yaml
+++ b/ansible/roles/scoop/tasks/12-install-packages.yaml
@@ -4,7 +4,7 @@
   ansible.windows.win_shell: >-
     scoop install {{ item.name }}
     {{ (item.global is defined and item.global and '--global') or '' }}
-  register: install_package
-  changed_when: install_package.stdout is search('was installed successfully!')
+  register: scoop_install_package
+  changed_when: scoop_install_package.stdout is search('was installed successfully!')
   loop: '{{ scoop_packages }}'
   ignore_errors: true

--- a/ansible/roles/scoop/tasks/13-configure-scoop-packages.yaml
+++ b/ansible/roles/scoop/tasks/13-configure-scoop-packages.yaml
@@ -11,7 +11,7 @@
     url: https://winscp.net/translations/dll/5.15.9/jp.zip
     dest: '{{ temporary_home }}\winscp_tran_5.15.9_jp.zip'
     force: false
-  register: download_tran_winscp
+  register: scoop_download_tran_winscp
   ignore_errors: true
   when: false
 
@@ -19,17 +19,17 @@
   community.windows.win_unzip:
     src: '{{ temporary_home }}\winscp_tran_5.15.9_jp.zip'
     dest: C:\ProgramData\scoop\apps\winscp\current\Translations
-  # when: download_tran_winscp.changed == true
+  # when: scoop_download_tran_winscp.changed == true
   when: false
 
 # pre-commitで参照しているsqlite3パッケージが動かないので追加
 - name: 13-configure-scoop-packages | Find scoop\shims\sqlite3.dll
   ansible.windows.win_stat:
     path: C:\ProgramData\scoop\shims\sqlite3.dll
-  register: find_sqlite3_dll
+  register: scoop_find_sqlite3_dll
 
 - name: 13-configure-scoop-packages | Add sqlite3.dll to scoop\shims
-  when: not find_sqlite3_dll.stat.exists
+  when: not scoop_find_sqlite3_dll.stat.exists
   block:
     - name: 13-configure-scoop-packages | Download sqlite3.dll
       ansible.windows.win_get_url:

--- a/ansible/roles/winget/tasks/10-upgrade-packages.yaml
+++ b/ansible/roles/winget/tasks/10-upgrade-packages.yaml
@@ -2,6 +2,6 @@
 - name: 10-upgrade-packages | Upgrade all packages
   become: true
   ansible.windows.win_shell: winget upgrade --all
-  register: upgrade_all
-  changed_when: upgrade_all.stdout is not search('適用可能な更新は見つかりませんでした。')
-  failed_when: upgrade_all.rc not in [0, 1]
+  register: winget_upgrade_all
+  changed_when: winget_upgrade_all.stdout is not search('適用可能な更新は見つかりませんでした。')
+  failed_when: winget_upgrade_all.rc not in [0, 1]

--- a/ansible/roles/winget/tasks/12-configure-winget-packages.yaml
+++ b/ansible/roles/winget/tasks/12-configure-winget-packages.yaml
@@ -18,7 +18,7 @@
       ansible.windows.win_shell: .\vswhere.exe -all -prerelease -latest -format json
       args:
         chdir: C:\Program Files (x86)\Microsoft Visual Studio\Installer
-      register: find_vs
+      register: winget_find_vs
       changed_when: false
       ignore_errors: true
 
@@ -26,16 +26,16 @@
         12-configure-winget-packages
         | Get information on latest installed version of Visual Studio
       ansible.builtin.set_fact:
-        vs_info: >-
-          {{ find_vs.stdout | default("[]")
+        winget_vs_info: >-
+          {{ winget_find_vs.stdout | default("[]")
           | from_json | first | default(none) }}
 
     - name: 12-configure-winget-packages | Install components for Visual Studio
       become: true
       ansible.windows.win_shell: >-
-        & "{{ vs_info.properties.setupEngineFilePath }}" modify
-        -p --norestart --channelId {{ vs_info.channelId }}
-        --productId {{ vs_info.productId }}
+        & "{{ winget_vs_info.properties.setupEngineFilePath }}" modify
+        -p --norestart --channelId {{ winget_vs_info.channelId }}
+        --productId {{ winget_vs_info.productId }}
         --config "{{ temporary_home }}\visual-studio\.vsconfig"
       changed_when: false
-      when: vs_info is mapping
+      when: winget_vs_info is mapping


### PR DESCRIPTION
solves: -

## 前提 / Prerequisites

- 9月分のソフトウェアアップデート
- リファクタリング

## なぜこのPRが必要になったか / Why do we need this PR

- 累積アップデート

## なにをやったか / What I did

- 廃止されたパッケージの削除
  - フォント周り
- インストールに失敗するアプリの退避
  - GIMP
  - InkSpace
- ターミナルの変更
  - iTerm2 → Rio
- ansible-lint実行陣に変数名で怒られる問題を解消
- set_global_path で "~/.dotnet/tools" のチルダが混入することによって ansible-lint の実行に失敗するようになる不具合の解消
  - チルダを$HOMEとして展開することで回避した

## 影響範囲  / Affected by the change

とくになし

## 懸念事項 / Concerns

pre-commit の ansible-lint が落ちてる